### PR TITLE
feat: support custom names for dict input/output tensors

### DIFF
--- a/torchvista/tracer.py
+++ b/torchvista/tracer.py
@@ -1,21 +1,21 @@
-import json
-import numbers
-import uuid
-import warnings
-from collections import OrderedDict, defaultdict
-from enum import Enum
-from importlib import resources
-from pathlib import Path
-from string import Template
-
-import numpy as np
 import torch
 import torch.nn as nn
+from collections import OrderedDict
 import torch.nn.functional as F
-from IPython.display import HTML, display
 from torch.overrides import get_ignored_functions
-
+from pathlib import Path
+from string import Template
+import uuid
+from collections import defaultdict
 from .overrides import CONTAINER_MODULES, FUNCTIONS
+import warnings
+
+import json
+from IPython.display import display, HTML
+import numpy as np
+import numbers
+from enum import Enum
+from importlib import resources
 
 
 class NodeType(Enum):
@@ -25,45 +25,38 @@ class NodeType(Enum):
     OUTPUT = "Output"
     CONSTANT = "Constant"
 
-
 class ExportFormat(Enum):
     SVG = "svg"
     HTML = "html"
     PNG = "png"
 
-
 def get_all_nn_modules():
-    import importlib
     import inspect
     import pkgutil
-
+    import importlib
     import torch.nn as nn
 
     try:
         import torchvision
     except ImportError:
         torchvision = None
-
+    
     try:
         import torchaudio
     except ImportError:
         torchaudio = None
     except Exception:
-        print(
-            '[warning] torchaudio available, but import failed and hence torchvista cannot trace torchaudio operations.\
-               If you need torchaudio tracing, run `import torchaudio` separately to debug what is wrong.'
-        )
+        print('[warning] torchaudio available, but import failed and hence torchvista cannot trace torchaudio operations.\
+               If you need torchaudio tracing, run `import torchaudio` separately to debug what is wrong.')
         torchaudio = None
-
+    
     try:
         import torchtext
     except ImportError:
         torchtext = None
     except Exception:
-        print(
-            '[warning] torchtext available, but import failed and hence torchvista cannot trace torchtext operations.\
-               If you need torchtext tracing, run `import torchtext` separately to debug what is wrong.'
-        )
+        print('[warning] torchtext available, but import failed and hence torchvista cannot trace torchtext operations.\
+               If you need torchtext tracing, run `import torchtext` separately to debug what is wrong.')
         torchtext = None
 
     modules_to_scan = [nn, torchvision, torchaudio, torchtext]
@@ -98,15 +91,12 @@ def get_all_nn_modules():
 
     return module_classes
 
-
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", UserWarning)
     MODULES = get_all_nn_modules() - CONTAINER_MODULES
 
 
-def process_graph(model, inputs, adj_list, module_info, func_info, node_to_module_path,
-                  parent_module_to_nodes, parent_module_to_depth, graph_node_name_to_without_suffix,
-                  node_to_ancestors, show_non_gradient_nodes, forced_module_tracing_depth):
+def process_graph(model, inputs, adj_list, module_info, func_info, node_to_module_path, parent_module_to_nodes, parent_module_to_depth, graph_node_name_to_without_suffix, node_to_ancestors, show_non_gradient_nodes, forced_module_tracing_depth):
     last_successful_op = None
     current_op = None
     current_executing_module = None
@@ -127,8 +117,8 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
     constant_node_names = []
     output_node_set = set()
 
-    def format_dims(dims):
 
+    def format_dims(dims):
         def helper():
             if isinstance(dims, tuple):
                 return f"({', '.join(map(str, dims))})"
@@ -136,9 +126,8 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
                 return f"[{', '.join(helper(d) for d in dims)}]"
             else:
                 return "()" if str(dims) == "()" else str(dims)
-
         result = helper()
-        return "( )" if result == "()" else result
+        return "( )" if result == "()"  else result
 
     def get_unique_op_name(op_type, module=None):
         nonlocal op_type_counters, module_to_node_name, module_info, module_reuse_count
@@ -179,12 +168,19 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
         return info
 
     def format_arg(arg):
-
         def _format(value):
             if isinstance(value, torch.Tensor):
-                return {"_type": "tensor", "shape": list(value.shape), "dtype": str(value.dtype)}
+                return {
+                    "_type": "tensor",
+                    "shape": list(value.shape),
+                    "dtype": str(value.dtype)
+                }
             elif isinstance(value, np.ndarray):
-                return {"_type": "ndarray", "shape": list(value.shape), "dtype": str(value.dtype)}
+                return {
+                    "_type": "ndarray",
+                    "shape": list(value.shape),
+                    "dtype": str(value.dtype)
+                }
             elif isinstance(value, (list, tuple)):
                 return [_format(v) for v in value]
             elif isinstance(value, dict):
@@ -206,9 +202,12 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
 
     def record_op_parameters(op_name, *args, **kwargs):
         formatted_args, formatted_kwargs = capture_args(*args, **kwargs)
-        func_info[op_name] = {"positional_args": formatted_args, "keyword_args": formatted_kwargs}
+        func_info[op_name] = {
+            "positional_args": formatted_args,
+            "keyword_args": formatted_kwargs
+        }
 
-    def pre_trace_op(op_name, node_type, *args, **kwargs):
+    def pre_trace_op(op_name, node_type, *args, **kwargs):        
         nonlocal current_op, last_successful_op, last_tensor_input_id, last_np_array_input_id, last_numeric_input_id
 
         input_tensors = extract_tensors_from_obj(args) + extract_tensors_from_obj(kwargs)
@@ -221,7 +220,7 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
             'failed': True,
             'node_type': node_type,
         }
-
+        
         for inp in input_tensors:
             if hasattr(inp, '_tensor_source_name'):
                 dims = format_dims(tuple(inp.shape))
@@ -253,14 +252,7 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
                         'failed': False,
                         'node_type': NodeType.CONSTANT.value,
                     }
-                    adj_list[f'np_array_{last_np_array_input_id}']['edges'].append({
-                        'target':
-                        op_name,
-                        'dims':
-                        dims,
-                        'edge_data_id':
-                        id(inp),
-                    })
+                    adj_list[f'np_array_{last_np_array_input_id}']['edges'].append({'target': op_name, 'dims': dims, 'edge_data_id': id(inp),})
                     constant_node_names.append(f'np_array_{last_np_array_input_id}')
                     node_to_ancestors[f'np_array_{last_np_array_input_id}'] = module_stack[::-1]
                     last_np_array_input_id += 1
@@ -293,22 +285,16 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
         depth = 1
         for parent in module_stack[::-1]:
             parent_module_to_nodes[parent].append(op_name)
-            parent_module_to_depth[parent] = max(
-                depth,
-                0 if parent not in parent_module_to_depth else parent_module_to_depth[parent])
+            parent_module_to_depth[parent] = max(depth, 0 if parent not in parent_module_to_depth else parent_module_to_depth[parent])
             depth += 1
 
         node_to_ancestors[op_name] = module_stack[::-1]
 
         return op_name
 
-    def extract_tensors_from_obj(obj,
-                                 max_depth=5,
-                                 current_depth=0,
-                                 return_paths=False,
-                                 path_prefix=""):
+    def extract_tensors_from_obj(obj, max_depth=5, current_depth=0, return_paths=False, path_prefix=""):
         """Recursively extracts all tensors from any object structure.
-
+        
         Args:
             obj: Any object that might contain tensors
             max_depth: Maximum recursion depth to prevent infinite loops
@@ -316,7 +302,7 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
             return_paths: If True, returns list of tuples [(tensor, path), ...]
                          If False, returns list of tensors [tensor, ...]
             path_prefix: Current path prefix (e.g., dict key). Only used when return_paths=True
-
+            
         Returns:
             List of tensors or list of (tensor, path) tuples depending on return_paths
         """
@@ -324,7 +310,7 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
             return []
         if current_depth >= max_depth:
             return []
-
+        
         # Base case: object is a tensor
         if isinstance(obj, torch.Tensor):
             if return_paths:
@@ -333,28 +319,19 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
                 return [(obj, path)]
             else:
                 return [obj]
-
+        
         # Recursive cases
         results = []
-
+        
         # Handle lists, tuples, and other iterables
         if isinstance(obj, (list, tuple, set)):
             for i, item in enumerate(obj):
                 if return_paths:
                     new_path = f"{path_prefix}[{i}]" if path_prefix else f"[{i}]"
-                    results.extend(
-                        extract_tensors_from_obj(item,
-                                                 max_depth,
-                                                 current_depth + 1,
-                                                 return_paths=True,
-                                                 path_prefix=new_path))
+                    results.extend(extract_tensors_from_obj(item, max_depth, current_depth + 1, return_paths=True, path_prefix=new_path))
                 else:
-                    results.extend(
-                        extract_tensors_from_obj(item,
-                                                 max_depth,
-                                                 current_depth + 1,
-                                                 return_paths=False))
-
+                    results.extend(extract_tensors_from_obj(item, max_depth, current_depth + 1, return_paths=False))
+        
         # Handle dictionaries
         elif isinstance(obj, dict):
             for key, value in obj.items():
@@ -368,26 +345,17 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
                     if not key_str:
                         key_str = 'key'
                     new_path = f"{path_prefix}.{key_str}" if path_prefix else key_str
-                    results.extend(
-                        extract_tensors_from_obj(value,
-                                                 max_depth,
-                                                 current_depth + 1,
-                                                 return_paths=True,
-                                                 path_prefix=new_path))
+                    results.extend(extract_tensors_from_obj(value, max_depth, current_depth + 1, return_paths=True, path_prefix=new_path))
                 else:
-                    results.extend(
-                        extract_tensors_from_obj(value,
-                                                 max_depth,
-                                                 current_depth + 1,
-                                                 return_paths=False))
-
+                    results.extend(extract_tensors_from_obj(value, max_depth, current_depth + 1, return_paths=False))
+        
         # Handle custom objects with accessible attributes
         elif hasattr(obj, '__dict__'):
             for attr_name in dir(obj):
                 # Skip private attributes and callable methods
                 if attr_name.startswith('_') or callable(getattr(obj, attr_name, None)):
                     continue
-
+                
                 try:
                     attr_value = getattr(obj, attr_name)
                     # Avoid problematic attributes like gradients
@@ -395,22 +363,13 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
                         continue
                     if return_paths:
                         new_path = f"{path_prefix}.{attr_name}" if path_prefix else attr_name
-                        results.extend(
-                            extract_tensors_from_obj(attr_value,
-                                                     max_depth,
-                                                     current_depth + 1,
-                                                     return_paths=True,
-                                                     path_prefix=new_path))
+                        results.extend(extract_tensors_from_obj(attr_value, max_depth, current_depth + 1, return_paths=True, path_prefix=new_path))
                     else:
-                        results.extend(
-                            extract_tensors_from_obj(attr_value,
-                                                     max_depth,
-                                                     current_depth + 1,
-                                                     return_paths=False))
+                        results.extend(extract_tensors_from_obj(attr_value, max_depth, current_depth + 1, return_paths=False))
                 except:
                     # Skip attributes that cause errors
                     continue
-
+        
         return results
 
     def trace_op(op_name, output, is_implied_edge=False):
@@ -426,9 +385,9 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
             # No tensors found in the output
             nodes_to_delete.append(op_name)
             return output
-
+        
         adj_list[op_name]['failed'] = False
-
+        
         # Tag each tensor with the source operation
         for tensor in output_tensors:
             tensor._tensor_source_name = op_name
@@ -447,16 +406,14 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
 
         def wrapped_forward(*args, **kwargs):
             nonlocal current_executing_module, forced_module_tracing_depth
-            if forced_module_tracing_depth is not None and forced_module_tracing_depth < len(
-                    module_stack):
+            if forced_module_tracing_depth is not None and forced_module_tracing_depth < len(module_stack):
                 # This module might have been overriden as a false positive
                 # (because it was at a lower depth in the named_children hierarchy)
                 return orig_forward(*args, **kwargs)
             is_traced = False
             if forced_module_tracing_depth is None and type(module) in MODULES:
                 is_traced = True
-            elif forced_module_tracing_depth is not None and forced_module_tracing_depth <= len(
-                    module_stack):
+            elif forced_module_tracing_depth is not None and forced_module_tracing_depth <= len(module_stack):
                 is_traced = True
             if is_traced:
                 current_executing_module = module
@@ -489,7 +446,7 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
     def traverse_model(model, depth=0, parent=None):
         for name, module in model.named_children():
             module_hierarchy[module] = parent
-
+            
             if has_forward_method(module):
                 # Some modules like ModuleList don't have forward() implemented
                 wrap_module(module)
@@ -505,19 +462,17 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
                 #     self.pos_embed = nn.Parameter(torch.randn(10, 1, 32))
                 #     self.encoder_layer = nn.TransformerEncoderLayer(d_model=32, nhead=4) <- gets passed below to TransformerEncoder
                 #     self.encoder = nn.TransformerEncoder(self.encoder_layer, num_layers=2)
-                #
+                # 
                 if list(module.named_children()):
                     if has_forward_method(module):
-                        traverse_model(module, depth=depth + 1, parent=module)
+                        traverse_model(module, depth=depth+1, parent=module)
                     else:
                         # If the module doesn't have a forward method this doesn't count towards the depth, and we want to traverse its children
                         # This happens to modules like ModuleList.
                         traverse_model(module, depth=depth, parent=module)
 
     def wrap_functions():
-
         def make_wrapped(orig_func, func_name, namespace):
-
             def wrapped(*args, **kwargs):
                 nonlocal current_executing_module, current_executing_function
                 if current_executing_module is None and current_executing_function is None:
@@ -543,13 +498,12 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
                     return output
                 else:
                     return orig_func(*args, **kwargs)
-
             return wrapped
 
         for func in FUNCTIONS:
             namespace = func['namespace']
             func_name = func['function']
-
+            
             if namespace == 'torch':
                 module = torch
             elif namespace == 'torch.functional':
@@ -577,7 +531,7 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
         for func in FUNCTIONS:
             namespace = func['namespace']
             func_name = func['function']
-
+            
             if namespace == 'torch':
                 module = torch
             elif namespace == 'torch.functional':
@@ -647,22 +601,21 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
                 del adj_list[node]
             for src_node, node_data in adj_list.items():
                 node_data['edges'] = [edge for edge in node_data['edges'] if edge['target'] != node]
-
+    
         # Step a: Identify all input nodes based on node_type
-        input_nodes = [
-            node for node, data in adj_list.items() if data.get('node_type') == NodeType.INPUT.value
-        ]
-
+        input_nodes = [node for node, data in adj_list.items() 
+                      if data.get('node_type') == NodeType.INPUT.value]
+        
         # Step 1: Forward DFS from all input nodes
         forward_reachable = set()
-
+    
         def dfs_forward(node):
             if node in forward_reachable:
                 return
             forward_reachable.add(node)
             for edge in adj_list.get(node, {}).get('edges', []):
                 dfs_forward(edge['target'])
-
+    
         # Run DFS from each input node
         for input_node in input_nodes:
             dfs_forward(input_node)
@@ -673,45 +626,46 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
             for edge in data.get('edges', []):
                 target = edge['target']
                 reverse_adj_list.setdefault(target, []).append(node)
-
+    
         # Step 3: Backward DFS from output nodes
         backward_reachable = set()
-
+    
         def dfs_backward(node):
             if node in backward_reachable:
                 return
             backward_reachable.add(node)
             for source in reverse_adj_list.get(node, []):
                 dfs_backward(source)
-
+    
         for output_node in output_node_set:
             if output_node in adj_list:
                 dfs_backward(output_node)
-
+    
         # Step 4: Union of forward and backward reachable sets
         base_set = forward_reachable.union(backward_reachable)
-
+    
         # Step 5: Expand to include ancestors of base set
         expanded_set = set()
-
+    
         def dfs_full_backward(node):
             if node in expanded_set:
                 return
             expanded_set.add(node)
             for source in reverse_adj_list.get(node, []):
                 dfs_full_backward(source)
-
+    
         for node in base_set:
             dfs_full_backward(node)
-
+    
         # Step 6: Prune graph to only keep expanded set
         for node in list(adj_list.keys()):
             if node not in expanded_set:
                 del adj_list[node]
-
+    
         for node_data in adj_list.values():
             node_data['edges'] = [edge for edge in node_data['edges'] if edge['target'] in adj_list]
 
+                
     try:
         wrap_functions()
         traverse_model(model)
@@ -752,24 +706,24 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
                 output_tensors_with_paths = extract_tensors_from_obj(output, return_paths=True)
                 if output_tensors_with_paths:
                     seen_tensors = {}
-
+                    
                     for output_tensor, path in output_tensors_with_paths:
                         tensor_id = id(output_tensor)
-
+        
                         # If we haven't seen this tensor before, create a node
                         if tensor_id not in seen_tensors:
                             output_node_name = f'output_{path}'
                             seen_tensors[tensor_id] = output_node_name
                             graph_node_name_to_without_suffix[output_node_name] = path
-
+        
                             adj_list[output_node_name] = {
                                 'edges': [],
                                 'failed': False,
                                 'node_type': NodeType.OUTPUT.value,
                             }
-
+        
                             output_node_set.add(output_node_name)
-
+        
                         # Always create the edge, pointing to the *correct* output node
                         dims = format_dims(tuple(output_tensor.shape))
                         target_node_name = seen_tensors[tensor_id]
@@ -780,35 +734,34 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
                                 'edge_data_id': id(output_tensor),
                             }
                             adj_list[output_tensor._tensor_source_name]['edges'].append(entry)
-                            if hasattr(output_tensor,
-                                       '_is_implied_edge') and output_tensor._is_implied_edge:
+                            if hasattr(output_tensor, '_is_implied_edge') and output_tensor._is_implied_edge:
                                 entry['is_implied_edge'] = True
-
+        
                     cleanup_tensor_attributes(output)
             else:
                 output_tensors = extract_tensors_from_obj(output)
                 if output_tensors:
                     output_node_name = 'output'
                     graph_node_name_to_without_suffix['output'] = 'output'
-
+                    
                     seen_tensors = {}
-
+                    
                     for i, output_tensor in enumerate(output_tensors):
                         tensor_id = id(output_tensor)
-
+        
                         # If we haven't seen this tensor before, create a node
                         if tensor_id not in seen_tensors:
                             output_node_name = f'output_{i}'
                             seen_tensors[tensor_id] = output_node_name
-
+        
                             adj_list[output_node_name] = {
                                 'edges': [],
                                 'failed': False,
                                 'node_type': NodeType.OUTPUT.value,
                             }
-
+        
                             output_node_set.add(output_node_name)
-
+        
                         # Always create the edge, pointing to the *correct* output node
                         dims = format_dims(tuple(output_tensor.shape))
                         target_node_name = seen_tensors[tensor_id]
@@ -819,12 +772,12 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
                                 'edge_data_id': id(output_tensor),
                             }
                             adj_list[output_tensor._tensor_source_name]['edges'].append(entry)
-                            if hasattr(output_tensor,
-                                       '_is_implied_edge') and output_tensor._is_implied_edge:
+                            if hasattr(output_tensor, '_is_implied_edge') and output_tensor._is_implied_edge:
                                 entry['is_implied_edge'] = True
-
+        
                     for output_tensor in output_tensors:
                         cleanup_tensor_attributes(output)
+
 
     except Exception as e:
         exception = e
@@ -838,7 +791,6 @@ def process_graph(model, inputs, adj_list, module_info, func_info, node_to_modul
     if exception is not None:
         raise exception
 
-
 def build_immediate_ancestor_map(ancestor_dict, adj_list):
     immediate_ancestor_map = {}
     for node, ancestors in ancestor_dict.items():
@@ -848,13 +800,11 @@ def build_immediate_ancestor_map(ancestor_dict, adj_list):
                 if ancestors[i] not in immediate_ancestor_map:
                     immediate_ancestor_map[ancestors[i]] = ancestors[i + 1]
     return immediate_ancestor_map
-
-
+    
 def generate_html_file_action(html_str, unique_id):
     output_file = Path.cwd() / f'torchvista_graph_{unique_id}.html'
     output_file.write_text(html_str, encoding='utf-8')
-    display(
-        HTML(f"""
+    display(HTML(f"""
         <style>
             #torchvista-container-{unique_id} {{
                 font-family: Arial, sans-serif;
@@ -886,10 +836,9 @@ def generate_html_file_action(html_str, unique_id):
         </div>
     """))
 
-
-def plot_graph(adj_list, module_info, func_info, node_to_module_path, parent_module_to_nodes,
-               parent_module_to_depth, graph_node_name_to_without_suffix, ancestor_map,
-               collapse_modules_after_depth, height, width, export_format):
+def plot_graph(adj_list, module_info, func_info, node_to_module_path,
+               parent_module_to_nodes, parent_module_to_depth, graph_node_name_to_without_suffix,
+               ancestor_map, collapse_modules_after_depth, height, width, export_format):
     unique_id = str(uuid.uuid4())
     template_str = resources.read_text('torchvista.templates', 'graph.html')
     d3_source = resources.read_text('torchvista.assets', 'd3.min.js')
@@ -898,46 +847,27 @@ def plot_graph(adj_list, module_info, func_info, node_to_module_path, parent_mod
     jsoneditor_source = resources.read_text('torchvista.assets', 'jsoneditor-10.2.0.min.js')
 
     template = Template(template_str)
-
+        
     output = template.safe_substitute({
-        'adj_list_json':
-        json.dumps(adj_list),
-        'module_info_json':
-        json.dumps(module_info),
-        'func_info_json':
-        json.dumps(func_info),
-        'parent_module_to_nodes_json':
-        json.dumps(parent_module_to_nodes),
-        'parent_module_to_depth_json':
-        json.dumps(parent_module_to_depth),
-        'graph_node_name_to_without_suffix':
-        json.dumps(graph_node_name_to_without_suffix),
-        'ancestor_map':
-        json.dumps(ancestor_map),
-        'unique_id':
-        unique_id,
-        'd3_source':
-        d3_source,
-        'viz_source':
-        viz_source,
-        'jsoneditor_css':
-        jsoneditor_css,
-        'jsoneditor_source':
-        jsoneditor_source,
-        'collapse_modules_after_depth':
-        collapse_modules_after_depth,
-        'node_to_module_path':
-        node_to_module_path,
-        'height':
-        f'{height}px' if (export_format not in (ExportFormat.PNG, ExportFormat.SVG)) else '0px',
-        'width':
-        f'{width}px' if width is not None else '100%',
-        'generate_image':
-        'true' if export_format is ExportFormat.PNG else 'false',
-        'generate_svg':
-        'true' if export_format is ExportFormat.SVG else 'false',
-        'show_modular_view':
-        'false',
+        'adj_list_json': json.dumps(adj_list),
+        'module_info_json': json.dumps(module_info),
+        'func_info_json': json.dumps(func_info),
+        'parent_module_to_nodes_json': json.dumps(parent_module_to_nodes),
+        'parent_module_to_depth_json': json.dumps(parent_module_to_depth),
+        'graph_node_name_to_without_suffix': json.dumps(graph_node_name_to_without_suffix),
+        'ancestor_map': json.dumps(ancestor_map),
+        'unique_id': unique_id,
+        'd3_source': d3_source,
+        'viz_source': viz_source,
+        'jsoneditor_css': jsoneditor_css,
+        'jsoneditor_source': jsoneditor_source,
+        'collapse_modules_after_depth': collapse_modules_after_depth,
+        'node_to_module_path': node_to_module_path,
+        'height': f'{height}px' if (export_format not in (ExportFormat.PNG, ExportFormat.SVG)) else '0px',
+        'width': f'{width}px' if width is not None else '100%',
+        'generate_image': 'true' if export_format is ExportFormat.PNG else 'false',
+        'generate_svg': 'true' if export_format is ExportFormat.SVG else 'false',
+        'show_modular_view': 'false',
     })
     if export_format == ExportFormat.HTML:
         generate_html_file_action(output, unique_id)
@@ -945,12 +875,7 @@ def plot_graph(adj_list, module_info, func_info, node_to_module_path, parent_mod
         display(HTML(output))
 
 
-def _get_demo_html_str(model,
-                       inputs,
-                       code_contents,
-                       collapse_modules_after_depth=1,
-                       show_non_gradient_nodes=True,
-                       forced_module_tracing_depth=None):
+def _get_demo_html_str(model, inputs, code_contents, collapse_modules_after_depth=1, show_non_gradient_nodes=True, forced_module_tracing_depth=None):
     collapse_modules_after_depth = max(collapse_modules_after_depth, 0)
     adj_list = {}
     module_info = {}
@@ -964,18 +889,7 @@ def _get_demo_html_str(model,
     exception = None
 
     try:
-        process_graph(model,
-                      inputs,
-                      adj_list,
-                      module_info,
-                      func_info,
-                      node_to_module_path,
-                      parent_module_to_nodes,
-                      parent_module_to_depth,
-                      graph_node_name_to_without_suffix,
-                      node_to_ancestors,
-                      show_non_gradient_nodes=show_non_gradient_nodes,
-                      forced_module_tracing_depth=forced_module_tracing_depth)
+        process_graph(model, inputs, adj_list, module_info, func_info, node_to_module_path, parent_module_to_nodes, parent_module_to_depth, graph_node_name_to_without_suffix, node_to_ancestors, show_non_gradient_nodes=show_non_gradient_nodes, forced_module_tracing_depth=forced_module_tracing_depth)
     except Exception as e:
         exception = e
 
@@ -987,42 +901,25 @@ def _get_demo_html_str(model,
     jsoneditor_source = resources.read_text('torchvista.assets', 'jsoneditor-10.2.0.min.js')
 
     template = Template(graph_template_str)
-
+    
     graph_output = template.safe_substitute({
-        'adj_list_json':
-        json.dumps(adj_list),
-        'module_info_json':
-        json.dumps(module_info),
-        'func_info_json':
-        json.dumps(func_info),
-        'parent_module_to_nodes_json':
-        json.dumps(parent_module_to_nodes),
-        'parent_module_to_depth_json':
-        json.dumps(parent_module_to_depth),
-        'graph_node_name_to_without_suffix':
-        json.dumps(graph_node_name_to_without_suffix),
-        'ancestor_map':
-        json.dumps(build_immediate_ancestor_map(node_to_ancestors, adj_list)),
-        'unique_id':
-        unique_id,
-        'd3_source':
-        d3_source,
-        'viz_source':
-        viz_source,
-        'jsoneditor_css':
-        jsoneditor_css,
-        'jsoneditor_source':
-        jsoneditor_source,
-        'collapse_modules_after_depth':
-        collapse_modules_after_depth,
-        'node_to_module_path':
-        node_to_module_path,
-        'generate_image':
-        'false',
-        'generate_svg':
-        'false',
-        'height':
-        '95%',
+        'adj_list_json': json.dumps(adj_list),
+        'module_info_json': json.dumps(module_info),
+        'func_info_json': json.dumps(func_info),
+        'parent_module_to_nodes_json': json.dumps(parent_module_to_nodes),
+        'parent_module_to_depth_json': json.dumps(parent_module_to_depth),
+        'graph_node_name_to_without_suffix': json.dumps(graph_node_name_to_without_suffix),
+        'ancestor_map': json.dumps(build_immediate_ancestor_map(node_to_ancestors, adj_list)),
+        'unique_id': unique_id,
+        'd3_source': d3_source,
+        'viz_source': viz_source,
+        'jsoneditor_css': jsoneditor_css,
+        'jsoneditor_source': jsoneditor_source,
+        'collapse_modules_after_depth': collapse_modules_after_depth,
+        'node_to_module_path': node_to_module_path,
+        'generate_image': 'false',
+        'generate_svg': 'false',
+        'height': '95%',
     })
 
     template_str = resources.read_text('torchvista.templates', 'demo-graph.html')
@@ -1034,7 +931,6 @@ def _get_demo_html_str(model,
     })
     return output, exception
 
-
 def validate_export_format(export_format):
     if export_format is None:
         return None
@@ -1043,19 +939,13 @@ def validate_export_format(export_format):
 
     valid_values = [e.value for e in ExportFormat]
     if export_format not in valid_values:
-        raise ValueError(f"Invalid export format: {export_format}. Must be one of {valid_values}.")
-
+        raise ValueError(
+            f"Invalid export format: {export_format}. Must be one of {valid_values}."
+        )
+    
     return ExportFormat(export_format)
 
-
-def trace_model(model,
-                inputs,
-                show_non_gradient_nodes=True,
-                collapse_modules_after_depth=1,
-                forced_module_tracing_depth=None,
-                height=800,
-                width=None,
-                export_format=None):
+def trace_model(model, inputs, show_non_gradient_nodes=True, collapse_modules_after_depth=1, forced_module_tracing_depth=None, height=800, width=None, export_format=None):
     adj_list = {}
     module_info = {}
     func_info = {}
@@ -1071,25 +961,12 @@ def trace_model(model,
     exception = None
 
     try:
-        process_graph(model,
-                      inputs,
-                      adj_list,
-                      module_info,
-                      func_info,
-                      node_to_module_path,
-                      parent_module_to_nodes,
-                      parent_module_to_depth,
-                      graph_node_name_to_without_suffix,
-                      node_to_ancestors,
-                      show_non_gradient_nodes=show_non_gradient_nodes,
-                      forced_module_tracing_depth=forced_module_tracing_depth)
+        process_graph(model, inputs, adj_list, module_info, func_info, node_to_module_path, parent_module_to_nodes, parent_module_to_depth, graph_node_name_to_without_suffix, node_to_ancestors, show_non_gradient_nodes=show_non_gradient_nodes, forced_module_tracing_depth=forced_module_tracing_depth)
     except Exception as e:
         exception = e
 
-    plot_graph(adj_list, module_info, func_info, node_to_module_path, parent_module_to_nodes,
-               parent_module_to_depth, graph_node_name_to_without_suffix,
-               build_immediate_ancestor_map(node_to_ancestors, adj_list),
-               collapse_modules_after_depth, height, width, export_format)
+    plot_graph(adj_list, module_info, func_info, node_to_module_path, parent_module_to_nodes, parent_module_to_depth, graph_node_name_to_without_suffix, build_immediate_ancestor_map(node_to_ancestors, adj_list), collapse_modules_after_depth, height, width, export_format)
+
 
     if exception is not None:
         raise exception


### PR DESCRIPTION
feat: support custom names for dict input/output tensors

Add support for **using dictionary keys as node names** in the computation graph when models use **dict-based input/output**. This improves graph readability by displaying meaningful names (e.g., `custom_input_a`, `cutom_output_b`) instead of generic indices (e.g., `input_0`, `output_0`).

Changes:
- Add `extract_tensors_with_paths()` function to extract tensors with their paths (dict keys) from nested structures
- Modify input processing to detect dict inputs and use keys as node names
- Modify output processing to detect dict outputs and use keys as node names
- Add key sanitization to handle special characters in dict keys
- Maintain backward compatibility for non-dict inputs/outputs

The implementation automatically handles nested dicts, lists, and tuples, and sanitizes dict keys to ensure valid node identifiers.

## Example 1

For example, I have a model which is composed of various sub-module, and all inputs and outputs of each sub-module are passed through a `dict`:
```py
import torch
import torch.nn as nn

from torchvista import trace_model


# Submodule 1
class FeatureExtractorA(nn.Module):
    def __init__(self, input_dim=10, hidden_dim=64):
        super().__init__()
        self.net = nn.Linear(input_dim, hidden_dim)

    def forward(self, data_dict):
        x = data_dict['x']
        features = self.net(x)
        data_dict['features_a'] = features
        return data_dict


# Submodule 2
class FeatureExtractorB(nn.Module):
    def __init__(self, input_dim=30, hidden_dim=64):
        super().__init__()
        self.net = nn.Linear(input_dim, hidden_dim)

    def forward(self, data_dict):
        y = data_dict['y']
        features = self.net(y)
        data_dict['features_b'] = features
        return data_dict


# Submodule 3
class AttentionModule(nn.Module):
    def __init__(self, dim=64):
        super().__init__()
        self.query = nn.Linear(dim, dim)
        self.key = nn.Linear(dim, dim)
        self.value = nn.Linear(dim, dim)
        self.softmax = nn.Softmax(dim=-1)

    def forward(self, data_dict):
        features_a = data_dict['features_a']
        features_b = data_dict['features_b']
        Q = self.query(features_a)
        K = self.key(features_b)
        V = self.value(features_b)

        attn_weights = self.softmax(torch.matmul(Q, K.transpose(-2, -1)))
        attended_features = torch.matmul(attn_weights, V)

        data_dict['attended_features'] = attended_features
        return data_dict


# Submodule 4
class ClassificationHead(nn.Module):
    def __init__(self, input_dim=64, num_classes=5):
        super().__init__()
        self.classifier = nn.Linear(input_dim, num_classes)

    def forward(self, data_dict):
        attended_features = data_dict['attended_features']
        logits = self.classifier(attended_features)
        data_dict['logits'] = logits
        return data_dict


# Submodule 5
class RegressionHead(nn.Module):
    def __init__(self, input_dim=64, out_dim=9):
        super().__init__()
        self.linear = nn.Linear(input_dim, out_dim)

    def forward(self, data_dict):
        attended_features = data_dict['attended_features']
        data_dict['out_vec'] = self.linear(attended_features)
        return data_dict


# Main model
class ComplexModel(nn.Module):
    def __init__(self):
        super().__init__()
        self.feature_extractor_a = FeatureExtractorA()
        self.feature_extractor_b = FeatureExtractorB()
        self.attention_module = AttentionModule()
        self.classification_head = ClassificationHead()
        self.regression_head = RegressionHead()

    def forward(self, data_dict):
        data_dict = self.feature_extractor_a(data_dict)
        data_dict = self.feature_extractor_b(data_dict)
        data_dict = self.attention_module(data_dict)
        data_dict = self.classification_head(data_dict)
        data_dict = self.regression_head(data_dict)
        return data_dict

batch_size = 2
data_dict = {
    'x': torch.randn(batch_size, 10),
    'y': torch.randn(batch_size, 30),
}
model = ComplexModel()

trace_model(model, data_dict, collapse_modules_after_depth=0)
```

Visualization of the original version:
<img width="2148" height="1460" alt="torchvista_tensor_no_name" src="https://github.com/user-attachments/assets/6b5d8ba5-b05d-46f4-a9e4-53acfaa02b11" />


Visualization of this change:
<img width="2176" height="1486" alt="torchvista_dict_key_tensor_name" src="https://github.com/user-attachments/assets/e43e7220-5b91-4ad9-8fe5-cf678e2a42c2" />

## Example 2: Nested Dict

```python
import torch
import torch.nn as nn

from torchvista import trace_model


class ModelWithNestedDictInput(nn.Module):
    def __init__(self):
        super().__init__()
        self.linear1 = nn.Linear(10, 32)
        self.linear2 = nn.Linear(20, 32)
        self.linear3 = nn.Linear(15, 32)
        self.fusion = nn.Linear(32, 16)
        self.classifier = nn.Linear(16, 5)

    def forward(self, data_dict):
        # Access nested dict keys: data_dict['inputs']['primary']
        x1 = data_dict['inputs']['primary']
        x1_features = self.linear1(x1)

        # Access deeply nested: data_dict['inputs']['nested']['level1']['tensor']
        x2 = data_dict['inputs']['nested']['level1']['tensor']
        x2_features = self.linear2(x2)

        # Access list element in nested dict: data_dict['inputs']['list_data'][0]
        x3 = data_dict['inputs']['list_data'][0]
        x3_features = self.linear3(x3)

        # Combine features
        combined = x1_features + x2_features + x3_features
        fused = self.fusion(combined)
        logits = self.classifier(fused)

        # Store outputs in nested structure
        data_dict['outputs'] = {
            'logits': logits,
            'features': {
                'fused': fused,
                'combined': combined
            }
        }
        return data_dict


# Create nested input structure
batch_size = 2
nested_data_dict = {
    'inputs': {
        'primary': torch.randn(batch_size, 10),
        'nested': {
            'level1': {
                'tensor': torch.randn(batch_size, 20),
            }
        },
        'list_data': [
            torch.randn(batch_size, 15),
        ]
    }
}

model = ModelWithNestedDictInput()

# Trace the model with nested dictionary input
trace_model(model, nested_data_dict, collapse_modules_after_depth=0)
```

<img width="1103" height="806" alt="image" src="https://github.com/user-attachments/assets/5c336497-3bd9-400e-a6c5-6ae79c7b6ba0" />


