### PR TITLE
Add missing semicolon in template graph.html

### DIFF
--- a/torchvista/templates/graph.html
+++ b/torchvista/templates/graph.html
@@ -48,7 +48,7 @@
         }
         text.collapse-icon_${unique_id} {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            font-size: 14px
+            font-size: 14px;
             cursor: default;
             user-select: none;
         }


### PR DESCRIPTION
This PR just adds a semicolon to the HTML graph template where it seems to be missing.